### PR TITLE
Fix DE browser integration extensions not working

### DIFF
--- a/firefox-aurora
+++ b/firefox-aurora
@@ -1,6 +1,17 @@
 #!/usr/bin/bash
 
-[ -z "$MOZ_DISABLE_WAYLAND" ] && { [ "$XDG_CURRENT_DESKTOP" == "GNOME" ] && [ -n "$WAYLAND_DISPLAY" ] || [ "$XDG_SESSION_TYPE" == "wayland" ]; } && export MOZ_ENABLE_WAYLAND=1 && export MOZ_DBUS_REMOTE=1
+[ -z "$MOZ_DISABLE_WAYLAND" ] && { [ "$XDG_CURRENT_DESKTOP" = "GNOME" ] && [ -n "$WAYLAND_DISPLAY" ] || [ "$XDG_SESSION_TYPE" = "wayland" ]; } && export MOZ_ENABLE_WAYLAND=1 && export MOZ_DBUS_REMOTE=1
+
+if [ "$XDG_CURRENT_DESKTOP" = "KDE" ] && [ ! -e "${HOME}/.mozilla/native-messaging-hosts/org.kde.plasma.browser_integration.json" ]; then
+    mkdir -p "${HOME}/.mozilla/native-messaging-hosts"
+    [ -r /usr/lib64/mozilla/native-messaging-hosts/org.kde.plasma.browser_integration.json ] && ln -s /usr/lib64/mozilla/native-messaging-hosts/org.kde.plasma.browser_integration.json "${HOME}/.mozilla/native-messaging-hosts/org.kde.plasma.browser_integration.json"
+fi
+
+if [ "$XDG_CURRENT_DESKTOP" = "GNOME" ] && { [ ! -e "${HOME}/.mozilla/native-messaging-hosts/org.gnome.browser_connector.json" ] || [ ! -e "${HOME}/.mozilla/native-messaging-hosts/org.gnome.chrome_gnome_shell.json" ]; }; then
+    mkdir -p "${HOME}/.mozilla/native-messaging-hosts"
+    [ -r /usr/lib64/mozilla/native-messaging-hosts/org.gnome.browser_connector.json ] && ln -s /usr/lib64/mozilla/native-messaging-hosts/org.gnome.browser_connector.json "${HOME}/.mozilla/native-messaging-hosts/org.gnome.browser_connector.json"
+    [ -r /usr/lib64/mozilla/native-messaging-hosts/org.gnome.chrome_gnome_shell.json ] && ln -s /usr/lib64/mozilla/native-messaging-hosts/org.gnome.chrome_gnome_shell.json "${HOME}/.mozilla/native-messaging-hosts/org.gnome.chrome_gnome_shell.json"
+fi
 
 export MOZ_APP_LAUNCHER="$0"
 

--- a/firefox-developer-edition.spec
+++ b/firefox-developer-edition.spec
@@ -5,7 +5,7 @@
 
 Name:               firefox-dev
 Version:            118.0b9
-Release:            2%{?dist}
+Release:            3%{?dist}
 Summary:            Firefox Developer Edition (formerly "Aurora") pre-beta Web browser
 
 License:            MPLv1.1 or GPLv2+ or LGPLv2+
@@ -16,6 +16,9 @@ Source2:            policies.json
 Source3:            %{internal_name}
 
 ExclusiveArch:      x86_64
+
+Recommends:         (plasma-browser-integration if plasma-workspace)
+Recommends:         (gnome-browser-connector if gnome-shell)
 
 Requires(post):     gtk-update-icon-cache
 
@@ -80,5 +83,8 @@ gtk-update-icon-cache -f -t %{_datadir}/icons/hicolor
 /opt/%{application_name}
 
 %changelog
+* Sat Sep 23 2023 Namelesswonder <Namelesswonder@users.noreply.github.com> - 118.0b9-3
+- firefox-developer-edition.spec: Add weak dependency for each DE browser integration
+
 * Tue Sep 12 2023 Namelesswonder <Namelesswonder@users.noreply.github.com> - 118.0b7-2
 - firefox-developer-edition.spec: Trim changelog to resolve date warnings and bump release


### PR DESCRIPTION
KDE Plasma Integration and GNOME Shell Integration both use Native Messaging to interact with a host process on the system. The manifest for these is installed to ```/usr/lib64/mozilla/native-messaging-hosts``` and this is where a distribution Firefox would search. However, Mozilla releases appear to not search under that path, and instead expect the manifests to be under ```$HOME/.mozilla/native-messaging-hosts```.

This PR resolves the extensions not working by extending the launcher to create symlinks to ```/usr/lib64/mozilla/native-messaging-hosts/*.json``` under ```$HOME/.mozilla/native-messaging-hosts``` depending on which desktop environment is being used.

Also the spec file is modified to add a weak dependency to the browser integration package that is fulfilled depending on the installed desktop environment.

The respective extension will have to be installed in the browser to take advantage of this, and if they are not then the host processes don't start so no extra resources are used.
https://addons.mozilla.org/en-US/firefox/addon/gnome-shell-integration/
https://addons.mozilla.org/en-US/firefox/addon/plasma-integration/