### PR TITLE
Fix GitHub Actions runner not resetting release number on version change and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ sudo dnf install firefox-dev
 4. Launch the application from the Application Menu or execute following command in terminal.
 
 ```Shell
-firefox-dev
+firefox-aurora
 ```

--- a/automation/index.js
+++ b/automation/index.js
@@ -38,7 +38,7 @@ function specUpdater(content, version) {
   if (versionIndex < 0) throw new Error('Failed to parse version line from spec file');
   const specVersion = lines[versionIndex].match(/\d.*$/);
   if (specVersion == null) throw new Error('Failed to parse version from spec file');
-  if (version !== specVersion) {
+  if (version != specVersion) {
     const releaseIndex = lines.findIndex((val) => val.startsWith('Release:'));
     if (releaseIndex < 0) throw new Error('Failed to parse release from spec file');
     lines[releaseIndex] = `Release:${whiteSpaces(12)}1%{?dist}`

--- a/automation/index.js
+++ b/automation/index.js
@@ -35,7 +35,14 @@ function specUpdater(content, version) {
   if (!content || !version) throw new Error('Invalid content or version');
   const lines = content.split('\n');
   const versionIndex = lines.findIndex((val) => val.startsWith('Version:'));
-  if (versionIndex < 0) throw new Error('Failed to parse current version');
+  if (versionIndex < 0) throw new Error('Failed to parse version line from spec file');
+  const specVersion = lines[versionIndex].match(/\d.*$/);
+  if (specVersion == null) throw new Error('Failed to parse version from spec file');
+  if (version !== specVersion) {
+    const releaseIndex = lines.findIndex((val) => val.startsWith('Release:'));
+    if (releaseIndex < 0) throw new Error('Failed to parse release from spec file');
+    lines[releaseIndex] = `Release:${whiteSpaces(12)}1%{?dist}`
+  }
   lines[versionIndex] = `Version:${whiteSpaces(12)}${version}`;
   return lines.join('\n');
 }


### PR DESCRIPTION
Packages should reset the release number back to 1 upon changing the version. The runner did not do so when setting the version, so any manual release bumps would end up persisting through version changes.

Added logic to reset the release number to 1 when the version number is changed.

I've tested the workflow and it functions correctly on version changes and when the version is still the same.

Also update README.md to replace old instance of firefox-dev with firefox-aurora. 
Will help those following the README along with slightly resolving #11