### PR TITLE
Move to xz packaging

### DIFF
--- a/firefox-developer-edition.spec
+++ b/firefox-developer-edition.spec
@@ -11,7 +11,7 @@ Summary:            Firefox Developer Edition (formerly "Aurora") pre-beta Web b
 
 License:            MPLv1.1 or GPLv2+ or LGPLv2+
 URL:                https://www.mozilla.org/en-US/firefox/developer/
-Source0:            https://download-installer.cdn.mozilla.net/pub/devedition/releases/%{version}/linux-x86_64/en-US/firefox-%{version}.tar.bz2
+Source0:            https://download-installer.cdn.mozilla.net/pub/devedition/releases/%{version}/linux-x86_64/en-US/firefox-%{version}.tar.xz
 Source1:            %{internal_name}.desktop
 Source2:            policies.json
 Source3:            %{internal_name}


### PR DESCRIPTION
The bzip packages are no longer used and breaking the build.

See https://blog.nightly.mozilla.org/2024/11/28/announcing-faster-lighter-firefox-downloads-for-linux-with-tar-xz-packaging/