### PR TITLE
Remove invalid runpath from libonnxruntime.so

### DIFF
--- a/firefox-developer-edition.spec
+++ b/firefox-developer-edition.spec
@@ -21,6 +21,8 @@ ExclusiveArch:      x86_64
 Recommends:         (plasma-browser-integration if plasma-workspace)
 Recommends:         (gnome-browser-connector if gnome-shell)
 
+BuildRequires:      chrpath
+
 Requires(post):     gtk-update-icon-cache
 
 %description
@@ -57,6 +59,8 @@ Bugs related to this package should be reported at this GitHub project:
 %__install -d %{buildroot}{/opt/%{application_name},%{_bindir},%{_datadir}/applications,%{_datadir}/icons/hicolor/128x128/apps,%{_datadir}/icons/hicolor/64x64/apps,%{_datadir}/icons/hicolor/48x48/apps,%{_datadir}/icons/hicolor/32x32/apps,%{_datadir}/icons/hicolor/16x16/apps}
 
 %__cp -r * %{buildroot}/opt/%{application_name}
+#ERROR   0002: file '/opt/firefox-dev/libonnxruntime.so' contains an invalid runpath '$' in [$]
+chrpath --delete %{buildroot}/opt/%{application_name}/libonnxruntime.so || :
 
 %__install -D -m 0644 %{SOURCE1} -t %{buildroot}%{_datadir}/applications
 
@@ -71,7 +75,7 @@ Bugs related to this package should be reported at this GitHub project:
 %__ln_s ../../../../../../opt/%{application_name}/browser/chrome/icons/default/default16.png %{buildroot}%{_datadir}/icons/hicolor/16x16/apps/%{full_name}.png
 
 %post
-gtk-update-icon-cache -f -t %{_datadir}/icons/hicolor
+gtk-update-icon-cache -ftq %{_datadir}/icons/hicolor
 
 %files
 %{_datadir}/applications/%{internal_name}.desktop


### PR DESCRIPTION
The issue I mentioned in #17 has manifested itself in your [latest build](https://copr.fedorainfracloud.org/coprs/the4runner/firefox-dev/build/9240129/), and can be identified from the line `ERROR   0002: file '/opt/firefox-dev/libonnxruntime.so' contains an invalid runpath '$' in [$]` in the [builder log](https://download.copr.fedorainfracloud.org/results/the4runner/firefox-dev/fedora-42-x86_64/09240129-firefox-dev/builder-live.log.gz).

This PR mitigates that by stripping the library of the invalid runpath using `chrpath` as described in the [Fedora Packaging Guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/#_removing_rpath), and also makes `gtk-update-icon-cache` quiet during updates (it was annoying me, and I've had this change on my nightly package for ages).

Thanks,
Elliott